### PR TITLE
mP's updated Redshift schema

### DIFF
--- a/mparticle_app_activity_dashboard.dashboard.lookml
+++ b/mparticle_app_activity_dashboard.dashboard.lookml
@@ -31,46 +31,46 @@
 
     - name: platform
       type: field_filter
-      explore: rawevents
-      field: rawevents.platform
+      explore: otherevents
+      field: otherevents.platform
 
     - name: is_debug_data
       type: field_filter
-      explore: rawevents
-      field: rawevents.is_debug
+      explore: otherevents
+      field: otherevents.is_debug
 
     - name: event_1
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
 
     - name: event_2
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
 
     - name: event_3
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
 
     - name: event_4
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
 
   elements:
     - name: session_count
       title: Session Count
       type: single_value
       model: mparticle_looker_blocks
-      explore: rawevents
-      measures: [rawevents.session_count]
+      explore: otherevents
+      measures: [otherevents.session_count]
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      sorts: [rawevents.event_type_id, rawevents.platform, rawevents.session_count desc]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      sorts: [otherevents.event_type_id, otherevents.platform, otherevents.session_count desc]
       limit: 500
       font_size: small
       height: 2
@@ -80,13 +80,13 @@
       title: Average Session Length (Seconds)
       type: single_value
       model: mparticle_looker_blocks
-      explore: rawevents
-      measures: [rawevents.avg_session_length]
+      explore: otherevents
+      measures: [otherevents.avg_session_length]
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      sorts: [rawevents.event_type_id, rawevents.platform, rawevents.avg_session_length desc]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      sorts: [otherevents.event_type_id, otherevents.platform, otherevents.avg_session_length desc]
       limit: 500
       font_size: small
       height: 2
@@ -96,13 +96,13 @@
       title: Total Installs
       type: single_value
       model: mparticle_looker_blocks
-      explore: rawevents
-      measures: [rawevents.install_count]
+      explore: otherevents
+      measures: [otherevents.install_count]
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      sorts: [rawevents.event_type_id, rawevents.platform, rawevents.install_count desc]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      sorts: [otherevents.event_type_id, otherevents.platform, otherevents.install_count desc]
       limit: 500
       font_size: small
       height: 2
@@ -112,14 +112,14 @@
       title: Active Users by App Platform
       type: looker_column
       model: mparticle_looker_blocks
-      explore: rawevents
-      dimensions: [rawevents.app_name_platform]
-      measures: [rawevents.unique_user_count]
+      explore: otherevents
+      dimensions: [otherevents.app_name_platform]
+      measures: [otherevents.unique_user_count]
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      sorts: [rawevents.unique_user_count desc]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      sorts: [otherevents.unique_user_count desc]
       limit: 500
       column_limit: 50
       show_row_numbers: true
@@ -153,20 +153,20 @@
       title: Session Count Breakdown by OS Version
       type: looker_column
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.os_version, rawevents.platform]
-      pivots: [rawevents.platform]
-      measures: [rawevents.session_count]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.os_version, otherevents.platform]
+      pivots: [otherevents.platform]
+      measures: [otherevents.session_count]
       dynamic_fields:
       - table_calculation: session_pct
         label: session_pct
-        expression: ${rawevents.session_count} / ${rawevents.session_count:total}
+        expression: ${otherevents.session_count} / ${otherevents.session_count:total}
         value_format: 0.0%
-      sorts: [rawevents.session_count desc 0, rawevents.platform]
+      sorts: [otherevents.session_count desc 0, otherevents.platform]
       limit: 500
       column_limit: 50
       total: true
@@ -189,7 +189,7 @@
       show_null_labels: false
       value_labels: legend
       label_type: labPer
-      hidden_fields: [rawevents.session_count]
+      hidden_fields: [otherevents.session_count]
       y_axis_labels: ['% of Sessions']
       y_axis_value_format: 0.0%
       x_axis_label: OS Version
@@ -198,15 +198,15 @@
       title: DAU by App Platform
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_name_platform, rawevents.event_date]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.unique_user_count]
-      sorts: [rawevents.event_date desc, rawevents.app_name_platform]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_name_platform, otherevents.event_date]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.unique_user_count]
+      sorts: [otherevents.event_date desc, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       show_view_names: true
@@ -238,15 +238,15 @@
       title: Daily Avg Session Length by App Platform
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.event_date, rawevents.app_name_platform]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.avg_session_length]
-      sorts: [rawevents.event_date desc, rawevents.app_name_platform]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.event_date, otherevents.app_name_platform]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.avg_session_length]
+      sorts: [otherevents.event_date desc, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -276,20 +276,20 @@
       title: Daily Time Spent In App Per User by App
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.event_date, rawevents.app_name_platform]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.time_spent_in_app, rawevents.unique_user_count]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.event_date, otherevents.app_name_platform]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.time_spent_in_app, otherevents.unique_user_count]
       dynamic_fields:
       - table_calculation: time_spent_in_app_per_user
         label: Time Spent In App Per User
-        expression: ${rawevents.time_spent_in_app} / ${rawevents.unique_user_count}
+        expression: ${otherevents.time_spent_in_app} / ${otherevents.unique_user_count}
         value_format: '0'
-      sorts: [rawevents.session_count desc 0, rawevents.platform, rawevents.app_name_platform]
+      sorts: [otherevents.session_count desc 0, otherevents.platform, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -312,21 +312,21 @@
       interpolation: linear
       x_axis_label: Date
       y_axis_labels: [Time Spent In App Per User (in sec)]
-      hidden_fields: [rawevents.unique_user_count, rawevents.time_spent_in_app]
+      hidden_fields: [otherevents.unique_user_count, otherevents.time_spent_in_app]
 
     - name: session_cnt_by_hour
       title: Session Count by Hour of Day by App
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_name_platform, rawevents.hour]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.session_count]
-      sorts: [rawevents.session_count desc 1, rawevents.app_name_platform]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_name_platform, otherevents.hour]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.session_count]
+      sorts: [otherevents.session_count desc 1, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       show_view_names: true
@@ -358,15 +358,15 @@
       title: Daily Installs by App Platform
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_name_platform, rawevents.event_date]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.install_count]
-      sorts: [rawevents.event_date desc, rawevents.app_name_platform]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_name_platform, otherevents.event_date]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.install_count]
+      sorts: [otherevents.event_date desc, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -396,15 +396,15 @@
       title: Daily Revenue by App Platform
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_name_platform, rawevents.event_date]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.revenue]
-      sorts: [rawevents.event_date desc, rawevents.app_name_platform]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_name_platform, otherevents.event_date]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.revenue]
+      sorts: [otherevents.event_date desc, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -435,15 +435,15 @@
       title: Daily Session Count by App Platform
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_name_platform, rawevents.event_date]
-      pivots: [rawevents.app_name_platform]
-      measures: [rawevents.session_count]
-      sorts: [rawevents.event_date desc, rawevents.app_name_platform]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_name_platform, otherevents.event_date]
+      pivots: [otherevents.app_name_platform]
+      measures: [otherevents.session_count]
+      sorts: [otherevents.event_date desc, otherevents.app_name_platform]
       limit: 500
       column_limit: 50
       stacking: normal
@@ -473,22 +473,22 @@
       title: Top 50 Event Name Stats
       type: table
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.event_name]
-      measures: [rawevents.count, rawevents.unique_user_count]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.event_name]
+      measures: [otherevents.count, otherevents.unique_user_count]
       dynamic_fields:
       - table_calculation: event_count_per_user
         label: Event count per user
-        expression: ${rawevents.count} / ${rawevents.unique_user_count}
+        expression: ${otherevents.count} / ${otherevents.unique_user_count}
         value_format: '0.00'
       filters:
-        rawevents.event_name: -EMPTY
-        rawevents.message_type_id: '4,16'
-      sorts: [rawevents.count desc]
+        otherevents.event_name: -EMPTY
+        otherevents.message_type_id: '4,16'
+      sorts: [otherevents.count desc]
       limit: 50
       column_limit: 50
       show_view_names: true
@@ -514,18 +514,18 @@
       title: Funnel Analytics by App Platform
       type: looker_column
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       measures: [funnel.event_1_uu_count, funnel.event_2_uu_count, funnel.event_3_uu_count,
         funnel.event_4_uu_count]
-      dimensions: [rawevents.app_name_platform]
+      dimensions: [otherevents.app_name_platform]
       listen:
-        date: rawevents.event_date
-        event_1: rawevents.event_1
-        event_2: rawevents.event_2
-        event_3: rawevents.event_3
-        event_4: rawevents.event_4
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
+        date: otherevents.event_date
+        event_1: otherevents.event_1
+        event_2: otherevents.event_2
+        event_3: otherevents.event_3
+        event_4: otherevents.event_4
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
       limit: 500
       column_limit: 50
       show_view_names: true
@@ -560,27 +560,27 @@
       title: User Retention by Attribution Source
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
+        date: otherevents.event_date
         install_date: users.install_timestamp_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.weeks_since_install, users.attribution_source]
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.weeks_since_install, users.attribution_source]
       pivots: [users.attribution_source]
-      measures: [rawevents.unique_user_count]
+      measures: [otherevents.unique_user_count]
       filters:
-        rawevents.weeks_since_install: NOT NULL
+        otherevents.weeks_since_install: NOT NULL
         users.attribution_source: -NULL
       dynamic_fields:
       - table_calculation: user_retention_pct
         label: user retention pct
-        expression: ${rawevents.unique_user_count} / max(${rawevents.unique_user_count})
+        expression: ${otherevents.unique_user_count} / max(${otherevents.unique_user_count})
         value_format: '#,##0.00%'
-      sorts: [rawevents.weeks_since_install, rawevents.unique_user_count desc 0, users.attribution_source]
+      sorts: [otherevents.weeks_since_install, otherevents.unique_user_count desc 0, users.attribution_source]
       limit: 500
       column_limit: 50
-      hidden_fields: [rawevents.unique_user_count]
+      hidden_fields: [otherevents.unique_user_count]
       show_row_numbers: true
       stacking: ''
       show_value_labels: false

--- a/mparticle_app_version_dashboard.dashboard.lookml
+++ b/mparticle_app_version_dashboard.dashboard.lookml
@@ -23,14 +23,14 @@
 
     - name: platform
       type: field_filter
-      explore: rawevents
-      field: rawevents.platform
+      explore: otherevents
+      field: otherevents.platform
       default_value: Android
 
     - name: is_debug_data
       type: field_filter
-      explore: rawevents
-      field: rawevents.is_debug
+      explore: otherevents
+      field: otherevents.is_debug
 
   elements:
 
@@ -38,14 +38,14 @@
       title: Total Sessions by App Version
       type: looker_column
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_version]
-      measures: [rawevents.session_count]
-      sorts: [rawevents.session_count desc]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_version]
+      measures: [otherevents.session_count]
+      sorts: [otherevents.session_count desc]
       limit: 500
       stacking: ''
       show_value_labels: false
@@ -71,15 +71,15 @@
       title: Daily Sessions by App Version
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_version, rawevents.event_date]
-      pivots: [rawevents.app_version]
-      measures: [rawevents.session_count]
-      sorts: [rawevents.session_count desc 1, rawevents.app_version]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_version, otherevents.event_date]
+      pivots: [otherevents.app_version]
+      measures: [otherevents.session_count]
+      sorts: [otherevents.session_count desc 1, otherevents.app_version]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -107,15 +107,15 @@
       title: Daily Avg Session Length by App Version
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_version, rawevents.eventhour_date]
-      pivots: [rawevents.app_version]
-      measures: [rawevents.avg_session_length]
-      sorts: [rawevents.session_count desc 1, rawevents.app_version]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_version, otherevents.eventhour_date]
+      pivots: [otherevents.app_version]
+      measures: [otherevents.avg_session_length]
+      sorts: [otherevents.session_count desc 1, otherevents.app_version]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -143,15 +143,15 @@
       title: Daily ARPU by App Version
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.app_version, rawevents.eventhour_date]
-      pivots: [rawevents.app_version]
-      measures: [rawevents.arpu]
-      sorts: [rawevents.session_count desc 1, rawevents.app_version]
+        date: otherevents.event_date
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.app_version, otherevents.eventhour_date]
+      pivots: [otherevents.app_version]
+      measures: [otherevents.arpu]
+      sorts: [otherevents.session_count desc 1, otherevents.app_version]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -179,27 +179,27 @@
       title: User Retention by App Version at Install
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
+        date: otherevents.event_date
         install_date: users.install_timestamp_date
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.weeks_since_install, users.app_version_at_install]
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.weeks_since_install, users.app_version_at_install]
       pivots: [users.app_version_at_install]
-      measures: [rawevents.unique_user_count]
+      measures: [otherevents.unique_user_count]
       filters:
-        rawevents.weeks_since_install: NOT NULL
+        otherevents.weeks_since_install: NOT NULL
         users.app_version_at_install: -NULL
       dynamic_fields:
       - table_calculation: user_retention_pct
         label: user retention pct
-        expression: ${rawevents.unique_user_count} / max(${rawevents.unique_user_count})
+        expression: ${otherevents.unique_user_count} / max(${otherevents.unique_user_count})
         value_format: '#,##0.00%'
-      sorts: [rawevents.weeks_since_install, rawevents.unique_user_count desc 0, users.app_version_at_install]
+      sorts: [otherevents.weeks_since_install, otherevents.unique_user_count desc 0, users.app_version_at_install]
       limit: 500
       column_limit: 50
-      hidden_fields: [rawevents.unique_user_count]
+      hidden_fields: [otherevents.unique_user_count]
       show_row_numbers: true
       stacking: ''
       show_value_labels: false

--- a/mparticle_audience_dashboard.dashboard.lookml
+++ b/mparticle_audience_dashboard.dashboard.lookml
@@ -18,18 +18,18 @@
 
     - name: platform
       type: field_filter
-      explore: rawevents
-      field: rawevents.platform
+      explore: otherevents
+      field: otherevents.platform
 
     - name: is_debug_data
       type: field_filter
-      explore: rawevents
-      field: rawevents.is_debug
+      explore: otherevents
+      field: otherevents.is_debug
 
     - name: audience_membership_filter
       type: field_filter
-      explore: rawevents
-      field: rawevents.audience_membership
+      explore: otherevents
+      field: otherevents.audience_membership
       default_value: '%"1234"%' ## when using this dashboard, users need to change the value to relevant audience ID for audience analytics
 
   elements:
@@ -37,21 +37,21 @@
       title: Audience Size by Day
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
-      dimensions: [rawevents.event_date]
-      measures: [rawevents.unique_user_count]
+      explore: otherevents
+      dimensions: [otherevents.event_date]
+      measures: [otherevents.unique_user_count]
       listen:
-        date: rawevents.event_date
-        audience_membership_filter: rawevents.audience_membership_filter
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
+        date: otherevents.event_date
+        audience_membership_filter: otherevents.audience_membership_filter
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
       filters:
-        rawevents.is_in_audience: 'Yes'
-      sorts: [rawevents.unique_user_count desc]
+        otherevents.is_in_audience: 'Yes'
+      sorts: [otherevents.unique_user_count desc]
       limit: 500
       column_limit: 50
       show_view_names: true
-      hidden_fields: [rawevents.count]
+      hidden_fields: [otherevents.count]
       show_null_points: true
       point_style: none
       interpolation: linear
@@ -79,27 +79,27 @@
       title: Audience Lift % (comparing users in the audience vs not in the audience)
       type: looker_column
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        audience_membership_filter: rawevents.audience_membership_filter
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.is_in_audience]
-      measures: [rawevents.avg_session_length, rawevents.time_spent_in_app, rawevents.unique_user_count,
-        rawevents.arpu, rawevents.session_count]
+        date: otherevents.event_date
+        audience_membership_filter: otherevents.audience_membership_filter
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.is_in_audience]
+      measures: [otherevents.avg_session_length, otherevents.time_spent_in_app, otherevents.unique_user_count,
+        otherevents.arpu, otherevents.session_count]
       dynamic_fields:
       - table_calculation: sessions_per_user
         label: Sessions Per User
-        expression: ${rawevents.session_count} / ${rawevents.unique_user_count}
+        expression: ${otherevents.session_count} / ${otherevents.unique_user_count}
         value_format: '#,##0.0'
       - table_calculation: time_spent_in_app_per_user
         label: Time Spent In App Per User
-        expression: ${rawevents.time_spent_in_app}/${rawevents.unique_user_count}
+        expression: ${otherevents.time_spent_in_app}/${otherevents.unique_user_count}
         value_format: '#,##0.0'
       - table_calculation: arpu_lift
         label: ARPU Lift %
-        expression: if(${rawevents.arpu} > 0, if(offset(${rawevents.arpu}, -1) > 0, ${rawevents.arpu} / offset(${rawevents.arpu}, -1) - 1, null), null)
+        expression: if(${otherevents.arpu} > 0, if(offset(${otherevents.arpu}, -1) > 0, ${otherevents.arpu} / offset(${otherevents.arpu}, -1) - 1, null), null)
         value_format: '#,##0.0%'
       - table_calculation: sessions_per_user_lift
         label: Sessions Per User Lift %
@@ -107,13 +107,13 @@
         value_format: '#,##0.0%'
       - table_calculation: avg_session_length_lift
         label: Avg Session Length Lift %
-        expression: ${rawevents.avg_session_length} / offset(${rawevents.avg_session_length}, -1) - 1
+        expression: ${otherevents.avg_session_length} / offset(${otherevents.avg_session_length}, -1) - 1
         value_format: '#,##0.0%'
       - table_calculation: time_spent_in_app_per_user_lift
         label: Time Spent In App Per User Lift %
         expression: ${time_spent_in_app_per_user} / offset(${time_spent_in_app_per_user}, -1) - 1
         value_format: '#,##0.0%'
-      sorts: [rawevents.is_in_audience]
+      sorts: [otherevents.is_in_audience]
       limit: 500
       column_limit: 50
       stacking: ''
@@ -133,26 +133,26 @@
       x_axis_scale: auto
       ordering: none
       show_null_labels: false
-      hidden_fields: [rawevents.time_spent_in_app, rawevents.unique_user_count, rawevents.arpu,
-        rawevents.session_count, time_spent_in_app_per_user, sessions_per_user, rawevents.avg_session_length]
+      hidden_fields: [otherevents.time_spent_in_app, otherevents.unique_user_count, otherevents.arpu,
+        otherevents.session_count, time_spent_in_app_per_user, sessions_per_user, otherevents.avg_session_length]
       y_axis_value_format: '#,##0.0%'
       y_axis_labels: [Lift %]
-      hidden_points_if_no: [rawevents.is_in_audience]
+      hidden_points_if_no: [otherevents.is_in_audience]
 
     - name: daily_arpu_by_audience
       title: Daily ARPU by Audience Membership
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        audience_membership_filter: rawevents.audience_membership_filter
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.is_in_audience, rawevents.event_date]
-      pivots: [rawevents.is_in_audience]
-      measures: [rawevents.arpu]
-      sorts: [rawevents.event_date desc, rawevents.is_in_audience desc]
+        date: otherevents.event_date
+        audience_membership_filter: otherevents.audience_membership_filter
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.is_in_audience, otherevents.event_date]
+      pivots: [otherevents.is_in_audience]
+      measures: [otherevents.arpu]
+      sorts: [otherevents.event_date desc, otherevents.is_in_audience desc]
       series_labels:
         'Yes': Is in Audience
         'No': Is not in Audience
@@ -183,23 +183,23 @@
       title: Daily Sessions Per User by Audience Membership
       type: looker_area
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        audience_membership_filter: rawevents.audience_membership_filter
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.is_in_audience, rawevents.event_date]
+        date: otherevents.event_date
+        audience_membership_filter: otherevents.audience_membership_filter
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.is_in_audience, otherevents.event_date]
       series_labels:
         'Yes': Is in Audience
         'No': Is not in Audience
-      pivots: [rawevents.is_in_audience]
-      measures: [rawevents.session_count, rawevents.unique_user_count]
+      pivots: [otherevents.is_in_audience]
+      measures: [otherevents.session_count, otherevents.unique_user_count]
       dynamic_fields:
       - table_calculation: sessions_per_user
         label: Sessions Per User
-        expression: ${rawevents.session_count} / ${rawevents.unique_user_count}
-      sorts: [rawevents.event_date desc, rawevents.is_in_audience desc]
+        expression: ${otherevents.session_count} / ${otherevents.unique_user_count}
+      sorts: [otherevents.event_date desc, otherevents.is_in_audience desc]
       limit: 500
       column_limit: 50
       stacking: normal
@@ -220,23 +220,23 @@
       show_null_points: true
       point_style: none
       interpolation: linear
-      hidden_fields: [rawevents.unique_user_count, rawevents.session_count]
+      hidden_fields: [otherevents.unique_user_count, otherevents.session_count]
       x_axis_label: Date
 
     - name: daily_avg_session_length
       title: Daily Avg Session Length by Audience Membership
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        audience_membership_filter: rawevents.audience_membership_filter
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.event_date, rawevents.is_in_audience]
-      pivots: [rawevents.is_in_audience]
-      measures: [rawevents.avg_session_length]
-      sorts: [rawevents.event_date desc, rawevents.is_in_audience desc]
+        date: otherevents.event_date
+        audience_membership_filter: otherevents.audience_membership_filter
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.event_date, otherevents.is_in_audience]
+      pivots: [otherevents.is_in_audience]
+      measures: [otherevents.avg_session_length]
+      sorts: [otherevents.event_date desc, otherevents.is_in_audience desc]
       limit: 500
       column_limit: 50
       series_labels:
@@ -267,24 +267,24 @@
       title: Daily Time Spent In App Per User by Audience Membership
       type: looker_line
       model: mparticle_looker_blocks
-      explore: rawevents
+      explore: otherevents
       listen:
-        date: rawevents.event_date
-        audience_membership_filter: rawevents.audience_membership_filter
-        platform: rawevents.platform
-        is_debug_data: rawevents.is_debug
-      dimensions: [rawevents.event_date, rawevents.is_in_audience]
-      pivots: [rawevents.is_in_audience]
-      measures: [rawevents.time_spent_in_app, rawevents.unique_user_count]
+        date: otherevents.event_date
+        audience_membership_filter: otherevents.audience_membership_filter
+        platform: otherevents.platform
+        is_debug_data: otherevents.is_debug
+      dimensions: [otherevents.event_date, otherevents.is_in_audience]
+      pivots: [otherevents.is_in_audience]
+      measures: [otherevents.time_spent_in_app, otherevents.unique_user_count]
       dynamic_fields:
       - table_calculation: time_spent_in_app_per_user_in_sec
         label: Time Spent In App Per User (in sec)
-        expression: ${rawevents.time_spent_in_app} / ${rawevents.unique_user_count}
+        expression: ${otherevents.time_spent_in_app} / ${otherevents.unique_user_count}
         value_format: '#,##0'
-      sorts: [rawevents.unique_user_count desc 1, rawevents.is_in_audience]
+      sorts: [otherevents.unique_user_count desc 1, otherevents.is_in_audience]
       limit: 500
       column_limit: 50
-      hidden_fields: [rawevents.time_spent_in_app, rawevents.unique_user_count]
+      hidden_fields: [otherevents.time_spent_in_app, otherevents.unique_user_count]
       stacking: ''
       series_labels:
         'Yes': Is in Audience
@@ -307,4 +307,3 @@
       point_style: none
       interpolation: linear
       x_axis_label: Date
-

--- a/mparticle_ecommerce_dashboard.dashboard.lookml
+++ b/mparticle_ecommerce_dashboard.dashboard.lookml
@@ -18,42 +18,42 @@
 
     - name: platform
       type: field_filter
-      explore: rawevents
-      field: rawevents.platform
+      explore: otherevents
+      field: otherevents.platform
 
     - name: is_debug_data
       type: field_filter
-      explore: rawevents
-      field: rawevents.is_debug
+      explore: otherevents
+      field: otherevents.is_debug
 
     - name: event_1
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
       default_value: "eCommerce - ViewDetail"
 
     - name: event_2
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
       default_value: "eCommerce - AddToWishlist"
 
     - name: event_3
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
       default_value: "eCommerce - AddToCart"
 
     - name: event_4
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
       default_value: "eCommerce - Checkout"
 
     - name: event_5
       type: field_filter
-      explore: rawevents
-      field: rawevents.event_name
+      explore: otherevents
+      field: otherevents.event_name
       default_value: "eCommerce - Purchase"
 
   elements:
@@ -62,13 +62,13 @@
     title: Total Revenue
     type: single_value
     model: mparticle_looker_blocks
-    explore: rawevents
-    measures: [rawevents.revenue]
+    explore: otherevents
+    measures: [otherevents.revenue]
     listen:
-      date: rawevents.event_date
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
-    sorts: [rawevents.revenue desc]
+      date: otherevents.event_date
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
+    sorts: [otherevents.revenue desc]
     limit: 500
     font_size: small
     height: 2
@@ -78,13 +78,13 @@
     title: Unique User Count
     type: single_value
     model: mparticle_looker_blocks
-    explore: rawevents
-    measures: [rawevents.unique_user_count]
+    explore: otherevents
+    measures: [otherevents.unique_user_count]
     listen:
-      date: rawevents.event_date
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
-    sorts: [rawevents.unique_user_count desc]
+      date: otherevents.event_date
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
+    sorts: [otherevents.unique_user_count desc]
     limit: 500
     font_size: small
     height: 2
@@ -94,13 +94,13 @@
     title: ARPU
     type: single_value
     model: mparticle_looker_blocks
-    explore: rawevents
-    measures: [rawevents.arpu]
+    explore: otherevents
+    measures: [otherevents.arpu]
     listen:
-      date: rawevents.event_date
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
-    sorts: [rawevents.arpu desc]
+      date: otherevents.event_date
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
+    sorts: [otherevents.arpu desc]
     limit: 500
     font_size: small
     height: 2
@@ -110,15 +110,15 @@
   - name: Revenue by Attribution Source
     title: Revenue by Attribution Source
     listen:
-      date: rawevents.event_date
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
+      date: otherevents.event_date
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
     type: looker_column
     model: mparticle_looker_blocks
-    explore: rawevents
-    dimensions: [rawevents.attribution_publisher_name]
-    measures: [rawevents.revenue, rawevents.arpu]
-    sorts: [rawevents.revenue desc]
+    explore: otherevents
+    dimensions: [otherevents.attribution_publisher_name]
+    measures: [otherevents.revenue, otherevents.arpu]
+    sorts: [otherevents.revenue desc]
     limit: 500
     stacking: ''
     show_value_labels: false
@@ -144,24 +144,24 @@
     y_axis_labels: [Total Revenue, ARPU]
     y_axis_value_format: $#,##0.00
     series_types:
-      rawevents.arpu: line
+      otherevents.arpu: line
     series_labels:
-      rawevents.arpu: ARPU
-      rawevents.revenue: Total Revenue
+      otherevents.arpu: ARPU
+      otherevents.revenue: Total Revenue
     y_axis_orientation: [left, right]
 
   - name: Revenue by Hour of Day
     title: Revenue by Hour of Day
     listen:
-      date: rawevents.event_date
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
+      date: otherevents.event_date
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
     type: looker_column
     model: mparticle_looker_blocks
-    explore: rawevents
-    dimensions: [rawevents.hour]
-    measures: [rawevents.revenue, rawevents.arpu]
-    sorts: [rawevents.hour]
+    explore: otherevents
+    dimensions: [otherevents.hour]
+    measures: [otherevents.revenue, otherevents.arpu]
+    sorts: [otherevents.hour]
     limit: 500
     stacking: ''
     show_value_labels: false
@@ -187,24 +187,24 @@
     y_axis_labels: [Total Revenue, ARPU]
     y_axis_value_format: $#,##0.00
     series_types:
-      rawevents.arpu: line
+      otherevents.arpu: line
     series_labels:
-      rawevents.arpu: ARPU
-      rawevents.revenue: Total Revenue
+      otherevents.arpu: ARPU
+      otherevents.revenue: Total Revenue
     y_axis_orientation: [left, right]
 
   - name: Revenue & ARPU by Day
     title: Revenue & ARPU by Day
     listen:
-      date: rawevents.event_date
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
+      date: otherevents.event_date
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
     type: looker_column
     model: mparticle_looker_blocks
-    explore: rawevents
-    dimensions: [rawevents.event_date]
-    measures: [rawevents.revenue, rawevents.arpu]
-    sorts: [rawevents.event_date]
+    explore: otherevents
+    dimensions: [otherevents.event_date]
+    measures: [otherevents.revenue, otherevents.arpu]
+    sorts: [otherevents.event_date]
     limit: 500
     stacking: ''
     show_value_labels: false
@@ -230,29 +230,29 @@
     y_axis_labels: [Total Revenue, ARPU]
     y_axis_value_format: $#,##0.00
     series_types:
-      rawevents.arpu: line
+      otherevents.arpu: line
     series_labels:
-      rawevents.arpu: ARPU
-      rawevents.revenue: Total Revenue
+      otherevents.arpu: ARPU
+      otherevents.revenue: Total Revenue
     y_axis_orientation: [left, right]
 
   - name: Purchase Funnel Analytics by App Platform
     title: Purchase Funnel Analytics by App Platform
     type: looker_column
     model: mparticle_looker_blocks
-    explore: rawevents
+    explore: otherevents
     measures: [funnel.event_1_uu_count, funnel.event_2_uu_count, funnel.event_3_uu_count,
       funnel.event_4_uu_count, funnel.event_5_uu_count]
-    #dimensions: [rawevents.app_name_platform]
+    #dimensions: [otherevents.app_name_platform]
     listen:
-      date: rawevents.event_date
-      event_1: rawevents.event_1
-      event_2: rawevents.event_2
-      event_3: rawevents.event_3
-      event_4: rawevents.event_4
-      event_5: rawevents.event_5
-      platform: rawevents.platform
-      is_debug_data: rawevents.is_debug
+      date: otherevents.event_date
+      event_1: otherevents.event_1
+      event_2: otherevents.event_2
+      event_3: otherevents.event_3
+      event_4: otherevents.event_4
+      event_5: otherevents.event_5
+      platform: otherevents.platform
+      is_debug_data: otherevents.is_debug
     limit: 500
     column_limit: 50
     show_view_names: true

--- a/mparticle_looker_blocks.model.lkml
+++ b/mparticle_looker_blocks.model.lkml
@@ -1,4 +1,4 @@
-connection: "qa_redshift"
+connection: "se_redshift"
 
 # include all the views
 include: "*.view"
@@ -6,11 +6,11 @@ include: "*.view"
 # include all the dashboards
 include: "*.dashboard"
 
-explore: rawevents {
-  sql_always_where: rawevents.eventtimestamp - coalesce(rawevents.firstseentimestamp, 0) >= 0 ;;
+explore: otherevents {
+  sql_always_where: otherevents.eventtimestamp - coalesce(otherevents.firstseentimestamp, 0) >= 0 ;;
 
   join: users {
-    sql_on: ${rawevents.mparticle_user_id} = ${users.mparticle_user_id} ;;
+    sql_on: ${otherevents.mparticle_user_id} = ${users.mparticle_user_id} ;;
     relationship: many_to_one
   }
 }

--- a/rawevents.view.lkml
+++ b/rawevents.view.lkml
@@ -1,6 +1,6 @@
-view: rawevents {
+view: otherevents {
   ## change to relevant schema name for block implementation
-  sql_table_name: app_191.eventsview ;;
+  sql_table_name: public.otherevents ;;
 
   dimension: app_id {
     type: number
@@ -310,8 +310,8 @@ view: rawevents {
 
   # Audience analytics fields #
   filter: audience_membership_filter {
-    suggest_explore: rawevents
-    suggest_dimension: rawevents.audience_membership
+    suggest_explore: otherevents
+    suggest_dimension: otherevents.audience_membership
     bypass_suggest_restrictions: yes
   }
 
@@ -323,27 +323,27 @@ view: rawevents {
   # Funnel Fields #
 
   filter: event_1 {
-    suggest_explore: rawevents
+    suggest_explore: otherevents
     suggest_dimension: event_name
   }
 
   filter: event_2 {
-    suggest_explore: rawevents
+    suggest_explore: otherevents
     suggest_dimension: event_name
   }
 
   filter: event_3 {
-    suggest_explore: rawevents
+    suggest_explore: otherevents
     suggest_dimension: event_name
   }
 
   filter: event_4 {
-    suggest_explore: rawevents
+    suggest_explore: otherevents
     suggest_dimension: event_name
   }
 
   filter: event_5 {
-    suggest_explore: rawevents
+    suggest_explore: otherevents
     suggest_dimension: event_name
   }
 

--- a/users.view.lkml
+++ b/users.view.lkml
@@ -16,7 +16,7 @@ view: users {
           isnull(sum(eventltvvalue), 0) as ltv,
           isnull(sum(case when messagetypeid = 2 then eventlength / 1000 end), 0) as time_spent_in_app,
           min(case when messagetypeid = 7 then appversion end) as app_version_at_install
-        from app_191.eventsview
+        from public.otherevents
         group by 1)
       where install_timestamp is not null
        ;;


### PR DESCRIPTION
mParticle now creates an `otherevents` table instead of `rawevents`. Updates reflect this.  